### PR TITLE
Updates old cleanEHR functions and references

### DIFF
--- a/R/sdc-anonymisation.R
+++ b/R/sdc-anonymisation.R
@@ -151,7 +151,7 @@ sdc.trial <- function(ccd, conf, remove.alive=T, verbose=F, k.anon=5,
 
     if (verbose)  cat("parsing the cleanEHR object ...\n")
 
-    demg <- data.table(suppressWarnings(demographic.patient.spell(ccd)))
+    demg <- data.table(suppressWarnings(ccd_demographic_spell(ccd)))
     demg <- remove.patients(demg, conf$removelist)
     demg <- append.age(demg)
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ We have made this repository public in the interests of transparency.
 
 ## Dependencies:
 * sdcMicro
-* ccdata
+* cleanEHR
 
 ## How to run:
 1. Prepare a YAML configuration file. You can use the following function to
@@ -18,7 +18,7 @@ template.conf("template.yaml")
 2. Using `sdc.trial` to find the most suitable parameters such as K-anonymity
 or L-diversity. If it is specified in the SOP, then this step can be skipped.
 
-3. Create the new ccdata using `anonymisation` function.
+3. Create the new cleanEHR using `anonymisation` function.
 
 
 ## Template code

--- a/vignettes/demo.Rmd
+++ b/vignettes/demo.Rmd
@@ -9,7 +9,7 @@ output:
 ---
 
 ```{r include=FALSE}
-library(ccdata)
+library(cleanEHR)
 library(ccanonym)
 library(pander)
 
@@ -56,7 +56,7 @@ time stamps to the hour difference to the admission time.
 
 
 ```{r}
-library(ccdata)
+library(cleanEHR)
 library(ccanonym)
 ```
 
@@ -83,7 +83,7 @@ pander(demg.table,  style = 'rmarkdown')
 # Simple anonymisation procedure
 ## Step 1: Prepare YAML configuration file
 Create a YAML configuration file as such, where the following variables are set
-up. The name of the items are the standard short name of _ccdata_ R package.
+up. The name of the items are the standard short name of _cleanEHR_ R package.
 Please see the 'ITEM\_REF.YAML'.
 
 * **Identifiable variables** (dirctVars), 


### PR DESCRIPTION
This contains changes needed to run ccanonym with the latest version of cleanEHR.

However, I've still got a failure:

```
Error in rbindlist(demogls, fill = TRUE):
  Class attributes at column 20 of input list at position 2 does not match with column 20 of input list at position 1. Coercion of objects of class 'factor' alone is handled internally by rbind/rbindlist at the moment.
```
the traceback shows it comes from `sdc.trial(...)` -> `data.table(ccd_demographic_spell(ccd))` -> `ccd_demographic_table(rec)`

I got that only with `release-public2.yaml`, the others seem not having all the keys needed.